### PR TITLE
Remove sgctlaxcala.com.mx references

### DIFF
--- a/conf/cerebro_nginx.conf
+++ b/conf/cerebro_nginx.conf
@@ -4,7 +4,9 @@ upstream cerebro_server {
 
 
 server {
-  server_name sgctlaxcala.com.mx www.sgctlaxcala.com.mx;
+  listen 80;
+  listen [::]:80;
+  server_name _;
   client_max_body_size 4G;
 
   access_log /home/javier/Projects/logs/cerebro_nginx-access.log;
@@ -45,27 +47,4 @@ server {
     root /home/javier/Projects/cerebro/src/staticfiles/;
   }
 
-    listen [::]:443 ssl ipv6only=on; # managed by Certbot
-    listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/sgctlaxcala.com.mx/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/sgctlaxcala.com.mx/privkey.pem; # managed by Certbot
-    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-}
-
-server {
-    if ($host = www.sgctlaxcala.com.mx) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
-
-    if ($host = sgctlaxcala.com.mx) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
-
-    listen 80;
-    server_name sgctlaxcala.com.mx www.sgctlaxcala.com.mx;
-    # listen [::]:80 ipv6only=on;
-    return 404; # managed by Certbot
 }

--- a/container/.env.container.example
+++ b/container/.env.container.example
@@ -7,7 +7,8 @@
 DJANGO_SETTINGS_MODULE=core.settings
 SECRET_KEY=cambia-esto-por-una-clave-segura-de-50-chars
 DEBUG=False
-ALLOWED_HOSTS=172.19.17.22,sgctlaxcala.com.mx,www.sgctlaxcala.com.mx,localhost
+ALLOWED_HOSTS=172.19.17.22,localhost,127.0.0.1
+SITE_URL=http://127.0.0.1:8000
 
 # Base de datos
 DB_NAME=cerebro

--- a/src/apps/docs/management/commands/notificar_docs.py
+++ b/src/apps/docs/management/commands/notificar_docs.py
@@ -3,6 +3,7 @@ import logging
 import pytz
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -43,6 +44,7 @@ class Command(BaseCommand):
         context = {
             "revisiones": revisiones_pendientes,
             "fecha_notificacion": ahora.strftime("%d/%b/%Y"),
+            "site_url": settings.SITE_URL,
         }
 
         asunto = f"Documentos actualizados a la fecha {context['fecha_notificacion']}"

--- a/src/apps/docs/templates/docs/notificacion_periodica.html
+++ b/src/apps/docs/templates/docs/notificacion_periodica.html
@@ -19,7 +19,7 @@
         <tbody>
             {% for revision in revisiones %}
             <tr>
-                <td><a href="https://sgctlaxcala.com.mx{% url 'docs:detalle' pk=revision.documento.pk %}" target=_blank>{{ revision.documento.nombre }}</a></td>
+                <td><a href="{{ site_url }}{% url 'docs:detalle' pk=revision.documento.pk %}" target=_blank>{{ revision.documento.nombre }}</a></td>
                 <td>{{ revision.revision }}</td>
                 <td>{{ revision.cambios|safe }}</td>
             </tr>

--- a/src/apps/docs/templates/docs/notificacion_periodica_content.html
+++ b/src/apps/docs/templates/docs/notificacion_periodica_content.html
@@ -14,7 +14,7 @@
     <tbody>
         {% for revision in revisiones %}
         <tr>
-            <td><a href="https://sgctlaxcala.com.mx{% url 'docs:detalle' pk=revision.documento.pk %}" target=_blank>{{ revision.documento.nombre }}</a></td>
+            <td><a href="{{ site_url }}{% url 'docs:detalle' pk=revision.documento.pk %}" target=_blank>{{ revision.documento.nombre }}</a></td>
             <td>{{ revision.revision }}</td>
             <td>{{ revision.cambios|safe }}</td>
         </tr>

--- a/src/apps/docs/templates/docs/notificacion_urgente.html
+++ b/src/apps/docs/templates/docs/notificacion_urgente.html
@@ -18,7 +18,7 @@
     </div>
 
     <hr />
-    <p>Puedes consultar el <a href="https://sgctlaxcala.com.mx{% url 'docs:detalle' documento.id %}" target=_blank>documento actualizado</a> en el Cuadro de Mando Integral.</p>
+    <p>Puedes consultar el <a href="{{ site_url }}{% url 'docs:detalle' documento.id %}" target=_blank>documento actualizado</a> en el Cuadro de Mando Integral.</p>
 
     <p>Saludos cordiales,<br>El equipo de Cerebro</p>
 {% endblock content %}

--- a/src/apps/docs/templates/docs/notificacion_urgente_content.html
+++ b/src/apps/docs/templates/docs/notificacion_urgente_content.html
@@ -13,6 +13,6 @@
 </div>
 
 <hr />
-<p>Puedes consultar el <a href="https://sgctlaxcala.com.mx{% url 'docs:detalle' documento.id %}" target=_blank>documento actualizado</a> en el Cuadro de Mando Integral.</p>
+<p>Puedes consultar el <a href="{{ site_url }}{% url 'docs:detalle' documento.id %}" target=_blank>documento actualizado</a> en el Cuadro de Mando Integral.</p>
 
 <p>Saludos cordiales,<br>El equipo de Cerebro</p>

--- a/src/apps/docs/views.py
+++ b/src/apps/docs/views.py
@@ -16,6 +16,7 @@ Incluye las siguientes vistas:
 
 from datetime import datetime
 from django.forms.models import BaseModelForm
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from watson import search as watson
 from django.urls import reverse_lazy
@@ -362,6 +363,7 @@ def envio_de_correo(request, destinatarios, asunto, documento, revision, autor):
                 "revision": revision,
                 "autor": autor,
                 "nombre_usuario": nombre_usuario,
+                "site_url": settings.SITE_URL,
             },
         )
         try:
@@ -402,6 +404,7 @@ def send_message(request, destinatarios, asunto, documento, revision, autor):
                 "revision": revision,
                 "autor": autor,
                 "nombre_usuario": nombre_usuario,
+                "site_url": settings.SITE_URL,
             },
         )
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -23,8 +23,18 @@ SECRET_KEY = env("SECRET_KEY")
 
 DEBUG = env("DEBUG", default=False)
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
-CSRF_TRUSTED_ORIGINS = ["https://sgctlaxcala.com.mx", "https://www.sgctlaxcala.com.mx"]
-CORS_ORIGIN_WHITELIST = ["https://sgctlaxcala.com.mx", "https://www.sgctlaxcala.com.mx"]
+SITE_URL = env(
+    "SITE_URL",
+    default="http://127.0.0.1:8000",
+).rstrip("/")
+CSRF_TRUSTED_ORIGINS = env.list(
+    "CSRF_TRUSTED_ORIGINS",
+    default=[],
+)
+CORS_ORIGIN_WHITELIST = env.list(
+    "CORS_ORIGIN_WHITELIST",
+    default=[],
+)
 
 if env("SSL", default=False) is True:
     SECURE_SSL_REDIRECT = False
@@ -114,7 +124,6 @@ if DEBUG:
         {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
         {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     ]
-    SITE_URL = "http://127.0.0.1:8000"
 else:
     AUTH_PASSWORD_VALIDATORS = [
         {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},


### PR DESCRIPTION
## Qué cambia

- elimina referencias activas a `sgctlaxcala.com.mx` del código y la plantilla de Nginx
- sustituye las URL fijas de notificaciones por `SITE_URL`
- hace configurables `CSRF_TRUSTED_ORIGINS` y `CORS_ORIGIN_WHITELIST`
- limpia el ejemplo de variables del contenedor

## Motivo

El dominio público está redirigiendo mediante Cloudflare a un sitio ajeno al SGC. La aplicación ya fue retirada de ese dominio y quedó accesible internamente mediante `http://10.29.0.35:8000`.

## Validación realizada

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- plantillas de notificación cargadas correctamente
- sin referencias activas al dominio en el proyecto
- sin referencias restantes en `docs_notificacion`
- servicio `cerebro` activo
- respuesta HTTP interna `200`

## Evidencia y respaldo

El historial Git no se reescribe. El respaldo operativo quedó fuera del repositorio en `/home/javier/backups/cerebro/domain-removal-20260729_113453`.