### PR TITLE
Enable sitewide Redis page cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ django-guardian
 django-recaptcha
 whitenoise
 WeasyPrint
+django-redis==7.0.0
+redis==8.0.1

--- a/src/apps/cecyrd/etl.py
+++ b/src/apps/cecyrd/etl.py
@@ -3,12 +3,14 @@ import zipfile
 import os
 import tempfile
 import threading
+import logging
 from datetime import datetime, timedelta
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.utils import timezone
 from apps.cecyrd.models import Tramite
 
 BATCH_SIZE = 1000
+logger = logging.getLogger(__name__)
 
 
 def convertir_fecha_para_db(fecha_str):
@@ -52,6 +54,17 @@ def registrar_progreso(task_id, status, progreso, msj=None, stats=None):
     if stats:
         data["stats"] = stats
     cache.set(task_id, data, timeout=3600)
+
+
+def invalidar_cache_paginas():
+    """Elimina páginas antiguas cuando termina una carga ETL."""
+    try:
+        caches["pages"].clear()
+        logger.info("Caché de páginas invalidado después del ETL.")
+    except Exception:
+        logger.exception(
+            "No se pudo invalidar el caché de páginas después del ETL."
+        )
 
 
 def procesar_archivo_background(task_id, file_path, is_zip, password):
@@ -218,6 +231,7 @@ def procesar_archivo_background(task_id, file_path, is_zip, password):
             f"✅ Base de datos sincronizada correctamente.",
             stats,
         )
+        invalidar_cache_paginas()
 
     except Exception as e:
         registrar_progreso(

--- a/src/core/cache_middleware.py
+++ b/src/core/cache_middleware.py
@@ -1,0 +1,169 @@
+"""Caché Redis selectivo para las páginas públicas de Cerebro."""
+
+from django.conf import settings
+from django.core.cache import caches
+from django.middleware.cache import (
+    FetchFromCacheMiddleware,
+    UpdateCacheMiddleware,
+)
+from django.utils.cache import patch_vary_headers
+
+
+CACHEABLE_PREFIXES = (
+    "/docs/",
+    "/pas/",
+    "/ideas/",
+    "/cartografia/",
+    "/cecyrd/",
+)
+
+ALWAYS_BYPASS_PREFIXES = (
+    "/admin/",
+    "/login/",
+    "/logout/",
+    "/tinymce/",
+    "/profiles/",
+    "/pmml/",
+    "/vozmac/",
+    "/api/",
+    "/assets/",
+    "/media/",
+    "/cartografia/paquetes/",
+    "/cecyrd/carga/",
+    "/cecyrd/api/etl/",
+    "/cecyrd/api/revision/",
+)
+
+MUTATION_SEGMENTS = {
+    "add",
+    "edit",
+    "delete",
+    "guardar",
+    "iniciar",
+    "progreso",
+    "setup",
+    "process_add",
+    "tipo_add",
+    "panic",
+    "panic_resolve",
+    "notificaciones",
+    "closure",
+}
+
+
+class CerebroCachePolicyMixin:
+    """Determina qué solicitudes pueden compartir una respuesta cacheada."""
+
+    @staticmethod
+    def request_is_cacheable(request):
+        if settings.DEBUG:
+            return False
+
+        if request.method not in {"GET", "HEAD"}:
+            return False
+
+        if request.headers.get("Authorization"):
+            return False
+
+        user = getattr(request, "user", None)
+        if user is not None and user.is_authenticated:
+            return False
+
+        if settings.SESSION_COOKIE_NAME in request.COOKIES:
+            return False
+
+        path = request.path_info
+
+        if path == "/":
+            return True
+
+        if path.startswith(ALWAYS_BYPASS_PREFIXES):
+            return False
+
+        if not path.startswith(CACHEABLE_PREFIXES):
+            return False
+
+        if path.startswith("/cecyrd/api/"):
+            return path.startswith("/cecyrd/api/dashboard/")
+
+        segments = {
+            segment
+            for segment in path.strip("/").split("/")
+            if segment
+        }
+
+        if segments.intersection(MUTATION_SEGMENTS):
+            return False
+
+        return True
+
+
+class SelectiveFetchFromCacheMiddleware(
+    CerebroCachePolicyMixin,
+    FetchFromCacheMiddleware,
+):
+    """Lee de Redis únicamente respuestas públicas y compartibles."""
+
+    def process_request(self, request):
+        eligible = self.request_is_cacheable(request)
+        request._cerebro_cache_eligible = eligible
+
+        if not eligible:
+            request._cache_update_cache = False
+            return None
+
+        response = super().process_request(request)
+
+        if response is not None:
+            response["X-Cerebro-Cache"] = "HIT"
+
+        return response
+
+
+class SelectiveUpdateCacheMiddleware(
+    CerebroCachePolicyMixin,
+    UpdateCacheMiddleware,
+):
+    """Guarda páginas públicas e invalida el caché tras escrituras."""
+
+    mutating_methods = {"POST", "PUT", "PATCH", "DELETE"}
+
+    def process_response(self, request, response):
+        if (
+            request.method in self.mutating_methods
+            and 200 <= response.status_code < 400
+        ):
+            caches["pages"].clear()
+
+        eligible = getattr(
+            request,
+            "_cerebro_cache_eligible",
+            False,
+        )
+
+        update_cache = getattr(
+            request,
+            "_cache_update_cache",
+            False,
+        )
+
+        if not eligible or not update_cache:
+            if response.get("X-Cerebro-Cache") != "HIT":
+                response["X-Cerebro-Cache"] = "BYPASS"
+            return response
+
+        if response.status_code != 200 or response.streaming:
+            request._cache_update_cache = False
+            response["X-Cerebro-Cache"] = "BYPASS"
+            return response
+
+        # Docs y PAS pueden responder HTML completo o fragmentos HTMX
+        # para la misma URL. Este encabezado separa ambas variantes.
+        patch_vary_headers(response, ("HX-Request",))
+
+        response["X-Cerebro-Cache"] = "MISS"
+        response["X-Cerebro-Cache-TTL"] = str(
+            settings.CACHE_MIDDLEWARE_SECONDS
+        )
+
+        return super().process_response(request, response)

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -77,14 +77,16 @@ LOCAL_APPS = [
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
+    "core.cache_middleware.SelectiveUpdateCacheMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    'whitenoise.middleware.WhiteNoiseMiddleware',
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "core.cache_middleware.SelectiveFetchFromCacheMiddleware",
 ]
 
 ROOT_URLCONF = "core.urls"
@@ -173,26 +175,53 @@ MESSAGE_TAGS = {
     messages.ERROR: "alert-danger",
 }
 
-# Configuración inteligente de Caché
+# Configuración de caché
+SITE_CACHE_SECONDS = env.int("SITE_CACHE_SECONDS", default=300)
+
 if DEBUG:
-    # En desarrollo (tu Windows): Usa la memoria local de la computadora
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "cerebro-dev-cache",
-        }
+            "LOCATION": "cerebro-dev-default",
+            "TIMEOUT": 3600,
+        },
+        "pages": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "cerebro-dev-pages",
+            "TIMEOUT": SITE_CACHE_SECONDS,
+        },
     }
 else:
-    # En producción (tu Debian): Usa el servidor Redis que acabamos de instalar
+    REDIS_OPTIONS = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        "SOCKET_CONNECT_TIMEOUT": 2,
+        "SOCKET_TIMEOUT": 2,
+        "CONNECTION_POOL_KWARGS": {
+            "max_connections": 100,
+            "protocol": 2,
+        },
+    }
+
     CACHES = {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": "redis://127.0.0.1:6379/1",
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            }
-        }
+            "OPTIONS": REDIS_OPTIONS,
+            "KEY_PREFIX": "cerebro-default",
+            "TIMEOUT": 3600,
+        },
+        "pages": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/2",
+            "OPTIONS": REDIS_OPTIONS,
+            "KEY_PREFIX": "cerebro-pages",
+            "TIMEOUT": SITE_CACHE_SECONDS,
+        },
     }
+
+CACHE_MIDDLEWARE_ALIAS = "pages"
+CACHE_MIDDLEWARE_SECONDS = SITE_CACHE_SECONDS
+CACHE_MIDDLEWARE_KEY_PREFIX = "cerebro-site-v1"
 
 LOGGING = {
     "disable_existing_loggers": False,


### PR DESCRIPTION
## Qué cambia

- agrega caché Redis selectivo para las páginas públicas de Cerebro
- separa el caché funcional en Redis DB 1 y el caché de páginas en Redis DB 2
- cachea Index, Docs, Planes/PAS, Ideas, PUSINEX, CECyRD y el API del tablero CECyRD
- excluye usuarios autenticados, cookies de sesión, formularios, administración, medios, estáticos, escrituras y progreso ETL
- separa respuestas HTMX mediante `Vary: HX-Request`
- invalida el caché de páginas después de escrituras exitosas y al finalizar el ETL
- fija `django-redis` y `redis` en `requirements.txt`
- fuerza RESP2 para evitar avisos incompatibles de notificaciones de mantenimiento

## Validación realizada

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python -m pip check`
- PING correcto para los aliases `default` y `pages`
- separación comprobada entre Redis DB 1 y DB 2
- TTL de páginas: 300 segundos
- solicitudes con sesión: `BYPASS`
- primera y segunda solicitud por ruta: `MISS/HIT`

## Rutas verificadas

- `/`
- `/docs/`
- `/pas/`
- `/ideas/`
- `/cartografia/`
- `/cecyrd/`
- `/cecyrd/api/dashboard/`

El servicio `cerebro` y `redis-server` permanecieron activos durante la validación.