### PR TITLE
Refactor Notificacion tipos con TextChoices

### DIFF
--- a/src/apps/docs/management/commands/notificar_docs.py
+++ b/src/apps/docs/management/commands/notificar_docs.py
@@ -99,7 +99,7 @@ class Command(BaseCommand):
             documento=None,
             revision_obj=None,
             destinatarios=", ".join([s.email_full for s in destinatarios]),
-            tipo="P",
+            tipo=Notificacion.Tipo.SEMANAL,
             asunto=asunto,
             cuerpo_html=cuerpo_html_para_notificacion,
         )

--- a/src/apps/docs/models.py
+++ b/src/apps/docs/models.py
@@ -388,12 +388,12 @@ class Notificacion(models.Model):
     - revisiones: Revisiones de documentos asociadas a la notificación.
     """
 
-    TIPOS = (
-        ('S', 'Semanal'),
-        ('U', 'Urgente')
-    )
+    class Tipo(models.TextChoices):
+        SEMANAL = "S", "Semanal"
+        URGENTE = "U", "Urgente"
+
     fecha_envio = models.DateTimeField(auto_now_add=True)
-    tipo = models.CharField(max_length=1, choices=TIPOS)
+    tipo = models.CharField(max_length=1, choices=Tipo.choices)
     asunto = models.CharField(max_length=255)
     cuerpo_html = models.TextField()
     documento = models.ForeignKey(Documento, on_delete=models.CASCADE, related_name='notificaciones', null=True, blank=True)


### PR DESCRIPTION
Se reemplazó la tupla `TIPOS` por el enum `Notificacion.Tipo` usando `models.TextChoices`, y el campo `tipo` ahora toma `Tipo.choices`. También se actualizó `notificar_docs` para usar `Notificacion.Tipo.SEMANAL` en lugar del literal "P", evitando valores mágicos e inconsistentes con los tipos definidos.